### PR TITLE
Update page title to include 'a11y'

### DIFF
--- a/dist/style-guide/index.html
+++ b/dist/style-guide/index.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-forms-checkboxes.html
+++ b/dist/style-guide/item-forms-checkboxes.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-forms-radio-buttons.html
+++ b/dist/style-guide/item-forms-radio-buttons.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-forms-search.html
+++ b/dist/style-guide/item-forms-search.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-forms-select-lists.html
+++ b/dist/style-guide/item-forms-select-lists.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-forms-text-fields.html
+++ b/dist/style-guide/item-forms-text-fields.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-forms.html
+++ b/dist/style-guide/item-forms.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-general-buttons.html
+++ b/dist/style-guide/item-general-buttons.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-general-colors.html
+++ b/dist/style-guide/item-general-colors.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-general-link-focus.html
+++ b/dist/style-guide/item-general-link-focus.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-general-read-more.html
+++ b/dist/style-guide/item-general-read-more.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-general-skip-links.html
+++ b/dist/style-guide/item-general-skip-links.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-general-typography.html
+++ b/dist/style-guide/item-general-typography.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-general.html
+++ b/dist/style-guide/item-general.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-media-audio.html
+++ b/dist/style-guide/item-media-audio.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-media-images.html
+++ b/dist/style-guide/item-media-images.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-media-svgs.html
+++ b/dist/style-guide/item-media-svgs.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-media-videos.html
+++ b/dist/style-guide/item-media-videos.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-media.html
+++ b/dist/style-guide/item-media.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-navigation-breadcrumbs.html
+++ b/dist/style-guide/item-navigation-breadcrumbs.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-navigation-footer-menu.html
+++ b/dist/style-guide/item-navigation-footer-menu.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-navigation-main-menu.html
+++ b/dist/style-guide/item-navigation-main-menu.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-navigation-navbar.html
+++ b/dist/style-guide/item-navigation-navbar.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-navigation-pagination.html
+++ b/dist/style-guide/item-navigation-pagination.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-navigation-tabs.html
+++ b/dist/style-guide/item-navigation-tabs.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-navigation.html
+++ b/dist/style-guide/item-navigation.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-structure-aria-labels.html
+++ b/dist/style-guide/item-structure-aria-labels.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-structure-aria-landmark-roles.html
+++ b/dist/style-guide/item-structure-aria-landmark-roles.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-structure-headings.html
+++ b/dist/style-guide/item-structure-headings.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-structure-lists.html
+++ b/dist/style-guide/item-structure-lists.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-structure-tables.html
+++ b/dist/style-guide/item-structure-tables.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/item-structure.html
+++ b/dist/style-guide/item-structure.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/section-forms.html
+++ b/dist/style-guide/section-forms.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/section-general.html
+++ b/dist/style-guide/section-general.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/section-media.html
+++ b/dist/style-guide/section-media.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/section-navigation.html
+++ b/dist/style-guide/section-navigation.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">

--- a/dist/style-guide/section-structure.html
+++ b/dist/style-guide/section-structure.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
+  <title>a11y Style Guide</title>
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">


### PR DESCRIPTION
In this improvement, I think it helps to show the full document title in browser tabs.

Thanks!