### PR TITLE
Creating gulp functions to publish build (dist) to Jeckyll

### DIFF
--- a/gulp-tasks/clean.js
+++ b/gulp-tasks/clean.js
@@ -29,5 +29,11 @@ module.exports = {
     return del([
       './dist/js/*'
     ], {force: true});
+  },
+
+  docs: function() {
+    return del([
+      './docs/*'
+    ], {force: true});
   }
 };

--- a/gulp-tasks/clean.js
+++ b/gulp-tasks/clean.js
@@ -33,7 +33,11 @@ module.exports = {
 
   docs: function() {
     return del([
-      './docs/*'
+      './docs/style-guide/',
+      './docs/css/',
+      './docs/assets/',
+      './docs/all/',
+      './docs/js/'
     ], {force: true});
   }
 };

--- a/gulp-tasks/move.js
+++ b/gulp-tasks/move.js
@@ -29,5 +29,12 @@ module.exports = {
         return path;
       }))
       .pipe(gulp.dest('./dist/js'));
+  },
+
+  docs: function() {
+    return gulp.src([
+      '*/**'
+    ], { base: './dist'})
+      .pipe(gulp.dest('./docs'));
   }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,6 +48,12 @@ gulp.task('move:js', function() {
   return taskMove.js();
 });
 
+// For working styleguide to work with Github Pages, we need
+// to copy the /dist folder into the /docs folder.
+gulp.task('move:docs', function() {
+  return taskMove.docs();
+})
+
 //=======================================================
 // Lint Sass and JavaScript
 //=======================================================
@@ -103,6 +109,11 @@ gulp.task('clean:css', function () {
 gulp.task('clean:js', function () {
   return taskClean.js();
 });
+
+// Clean Docs folder for new fresh documents.
+gulp.task('clean:docs', function() {
+  return taskClean.docs();
+})
 
 //=======================================================
 // Watch and recompile sass.


### PR DESCRIPTION
After building new style guide the following commands are available:

- gulp clean:docs - Removes old code from /docs except index and jeckyll settings.
- gulp move:docs - Move items from /dist to /docs.