### PR TITLE
issue 86: Jump to top button

### DIFF
--- a/src/global/js/back-to-top.js
+++ b/src/global/js/back-to-top.js
@@ -1,0 +1,41 @@
+;(function ( $, doc ) {
+  'use strict';
+
+  var $win = $(window);
+  var $html = $('html');
+  var scrollTimeout;  // global for any pending scrollTimeout
+
+  $win.scroll(function () {
+    if ( scrollTimeout ) {
+      // clear the timeout, if one is pending
+      clearTimeout(scrollTimeout);
+      scrollTimeout = null;
+    }
+    scrollTimeout = setTimeout(scrollHandler, 200);
+  });
+
+
+  var scrollHandler = function () {
+    if ( $win.scrollTop() >= 200 && !$html.hasClass('show-back-to-top') ) {
+      $html.addClass('show-back-to-top');
+    }
+    else if ( $win.scrollTop() <= 200 ) {
+      $html.removeClass('show-back-to-top');
+    }
+  };
+
+  if ( $win.scrollTop() >= 200 ) {
+    $html.addClass('show-back-to-top');
+  }
+
+  scrollHandler();
+
+
+  $('.back-to-top').on('click', function () {
+    var $targetNode = $(this).attr('href').split('#')[1];
+    $('#' + $targetNode).attr('tabindex', '-1');
+    $html.removeClass('show-back-to-top');
+    $('#' + $targetNode).focus();
+  });
+
+})( jQuery, this.document );

--- a/src/global/js/jump-link-fix.js
+++ b/src/global/js/jump-link-fix.js
@@ -1,0 +1,10 @@
+var jumpLinkFix = function () {
+  var el = document.getElementById( location.hash.substring( 1 ) );
+
+  if ( el ) {
+    if ( !/^(?:a|select|input|button|textarea)$/i.test( el.tagName ) ) {
+      el.tabIndex = -1;
+    }
+    el.focus();
+  } // if
+};

--- a/src/style-guide/builder/index.twig
+++ b/src/style-guide/builder/index.twig
@@ -60,6 +60,7 @@
           </ul>
         </nav>
       </div>
+
     </div>
 
     <main id="kss-main-content" class="kss-content" aria-label="content">
@@ -160,7 +161,14 @@
       {% endif %}
       </article>
     </main>
-</div>
+
+    <a href="#kss-main-content" class="back-to-top">
+      <span class="visuallyhidden">
+        Back to top
+      </span>
+    </a>
+
+  </div>
 
 <!-- SCRIPTS -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/src/style-guide/builder/kss-assets/kss.css
+++ b/src/style-guide/builder/kss-assets/kss.css
@@ -803,3 +803,23 @@ pre .regexp {
 .kss-menu-full-width:hover {
   border: 2px solid rgba(0, 0, 0, 0.25);
 }
+
+
+
+/*
+  back to top temporary styling
+ */
+.back-to-top {
+  background: #f00;
+  bottom: 0;
+  height: 40px;
+  position: fixed;
+  right: 0;
+  transform: translateY(100%);
+  transition: transform .2s ease-in-out;
+  width: 40px;
+}
+
+.show-back-to-top .back-to-top {
+  transform: translateY(0%);
+}


### PR DESCRIPTION
initial work for jump to top button functionality.

adds <a> markup to index.twig file that points to the <main> container ID.

adds jump-link-fix script to ensure that browsers that don’t properly set focus to unfocusable elements, will add a tabindex -1 to do so.

back-to-top.js adds in scroll handler script and functionality to show/hide the back to top link only when the page is scrolled a certain amount.

kss.css is the temporary home for the (horribly styled) back to top link.  please make this so much better :)