### PR TITLE
removing aria-labels from links

### DIFF
--- a/src/components/style-guide.md
+++ b/src/components/style-guide.md
@@ -1,5 +1,5 @@
-<div><h1>A11Y Style Guide</h1><div class="social-link-out"><a href="https://twitter.com/cariefisher" target="_blank" class="social-link-twitter" aria-label="Twitter account link"><span class="visuallyhidden">Twitter account link</span></a><a href="https://github.com/cehfisher" target="_blank" class="social-link-github" aria-label="GitHub account link"><span class="visuallyhidden">GitHub account link</span></a></div>
-<p>This application is a living style guide, generated from KSS documented styles...with an accessibility twist. No matter your level of development or accessibility expertise, there are ways to <a href="https://github.com/cehfisher/a11y-style-guide" target="_blank" aria-label="Accessibility style GitHub repo">help contribute</a>.</p></div>
+<div><h1>A11Y Style Guide</h1><div class="social-link-out"><a href="https://twitter.com/cariefisher" target="_blank" class="social-link-twitter"><span class="visuallyhidden">Carie Fisher on Twitter</span></a><a href="https://github.com/cehfisher" target="_blank" class="social-link-github"><span class="visuallyhidden">Carie Fisher on GitHub</span></a></div>
+<p>This application is a living style guide, generated from KSS documented styles...with an accessibility twist. No matter your level of development or accessibility expertise, there are ways to <a href="https://github.com/cehfisher/a11y-style-guide" target="_blank">help contribute <span class="visuallyhidden">to the a11y style guide</span></a>.</p></div>
 
 <div class="break"></div>
 <div><h2>How this all got started</h2>


### PR DESCRIPTION
the twitter and github links didn’t need the aria-labels since they already had the visually hidden text.  updated that text to be more specific as to what twitter/github pages they would lead user to.

also removed the aria-label from the ‘help contribute’ link, as it was rewriting the sentence to say “there are ways to ‘accessibility style github repo’” rather than the intended visual sentence.