### PR TITLE
update readmore link examples

### DIFF
--- a/src/components/read-more/read-more.scss
+++ b/src/components/read-more/read-more.scss
@@ -20,7 +20,7 @@
 .read-more {
 
   &::after {
-    content: ' > ';
+    content: '\003e';
     display: inline-block;
     padding-left: 5px;
   }

--- a/src/components/read-more/read-more.twig
+++ b/src/components/read-more/read-more.twig
@@ -1,11 +1,18 @@
 <section class="read-more-section">
-  <form action="#" method="post">
-    <h3>Example #1: Using aria-labelledby</h3>
-    <h4 id="headline" class="bold">Storms Hit East Coast</h4>
-    <p>Torrential rain and gale force winds have struck the east coast, causing flooding in many coastal towns. <a href="#" aria-labelledby="headline" class="read-more">Read More</a></p>
-    <div class="break"></div>
-    <h3>Example #2: Using aria-label</h3>
-    <h4 class="bold">Black Bears Trapped in Cars?</h4>
-    <p>Over the past three weeks there have been 15 reports or black bears getting themselves trapped in vehicles. There are several ways to prevent this from happening to you. <a href="#" aria-label="Learn more about trapped black bears" class="read-more">Read More</a></p>
-  </form>
+  <h3>Example #1: Using aria-labelledby</h3>
+  <h4 id="headline" class="bold">Storms Hit East Coast</h4>
+  <p>Torrential rain and gale force winds have struck the east coast, causing flooding in many coastal towns. <a href="#" aria-labelledby="headline" class="read-more">Read More</a></p>
+
+  <div class="break"></div>
+
+  <h3>Example #2: Using aria-label</h3>
+  <h4 class="bold">Black Bears Trapped in Cars?</h4>
+  <p>Over the past three weeks there have been 15 reports or black bears getting themselves trapped in vehicles. There are several ways to prevent this from happening to you. <a href="#" aria-label="Learn more about trapped black bears" class="read-more">Read More</a></p>
+
+  <div class="break"></div>
+
+  <h3>Example #3: Using visually hidden text</h3>
+  <h4 class="bold">Mass Hysteria</h4>
+  <p>Fire and brimstone, coming down from the skies. Rivers and seas boiling... Human sacrifice, dogs and cats, living together...
+  <a href="#" class="read-more">Read More <span class="visuallyhidden">about mass hysteria</span></a></p>
 </section>


### PR DESCRIPTION
remove wrapping form element, as it has no baring to the example content.

add example that doesn’t use aria attributes, and instead uses visually hidden text.