### PR TITLE
add visible label example

### DIFF
--- a/src/components/toggles/toggles.twig
+++ b/src/components/toggles/toggles.twig
@@ -1,7 +1,12 @@
 <section class="toggles-section">
-  <button type="button" data-action="aria-switch" aria-label="Toggle" aria-checked="false" role="switch">
-    <span></span>
-  </button>
+  <div>
+    <button type="button" data-action="aria-switch" aria-labelledby="toggle_label" aria-checked="false" role="switch">
+      <span></span>
+    </button>
+    <span id="toggle_label" style="display: inline-block; padding: 12px 12px 0 0;">
+      Night Mode
+    </span>
+  </div>
   <button type="button" data-action="aria-switch" aria-label="Toggle Text" aria-checked="true" role="switch" class="text">
     <span></span>
   </button>


### PR DESCRIPTION
toggle switches should most often be associated with a visual label of some sort, so updated the first example to represent this.