### PR TITLE
add license & repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "a11y_style_guide",
   "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cehfisher/a11y-style-guide.git"
+  },
   "scripts": {
     "build": "gulp",
     "compile": "gulp compile",


### PR DESCRIPTION
simply to negate the warnings that license and repository are undefined in the package.json, when using npm