### PR TITLE
video component updates

### DIFF
--- a/src/components/videos/videos.scss
+++ b/src/components/videos/videos.scss
@@ -10,7 +10,7 @@
 //
 // <blockquote>There are a ton of WCAG Guidelines for media on websites for a reason...there are a lot of factors to consider. Don't let that scare you though, there are also some easy wins. Just including some alternatives to the media you present (ex. transcript for a video) is half the battle.</blockquote>
 //
-// <section data-action="aria-toggle" class="atblock"><h3 class="atblock__title"><a href="#video_res">Resources</a></h3><div id="video_res" class="atblock__panel"><ul><li><a href="https://www.sitepoint.com/accessible-video" target="_blank">8 Steps to Creating Accessible Video</a></li><li><a href="https://www.w3.org/2008/06/video-notes" target="_blank">Multimedia Accessibility FAQ</a></li><li><a href="http://trace.umd.edu/peat" target="_blank">Photosensitive Epilepsy Analysis Tool</a> - tests your visual media to see if it will trigger seizures or other light disorder issues in viewers</a></li></ul></div></section>
+// <section data-action="aria-toggle" class="atblock"><h3 class="atblock__title"><a href="#video_res">Resources</a></h3><div id="video_res" class="atblock__panel"><ul><li><a href="https://www.sitepoint.com/accessible-video" target="_blank">8 Steps to Creating Accessible Video</a></li><li><a href="https://www.w3.org/2008/06/video-notes" target="_blank">Multimedia Accessibility FAQ</a></li><li><a href="http://trace.umd.edu/peat" target="_blank">Photosensitive Epilepsy Analysis Tool</a> - tests your visual media to see if it will trigger seizures or other light disorder issues in viewers</li></ul></div></section>
 //
 //
 //
@@ -24,3 +24,8 @@
 
 // Import site utilities.
 @import '../../global/utils/init';
+
+
+.videos {
+  margin: 0;
+}

--- a/src/components/videos/videos.twig
+++ b/src/components/videos/videos.twig
@@ -1,6 +1,6 @@
 <section class="videos-section">
-  <div class="videos">
-    <video controls="controls" poster="http://sandbox.thewikies.com/vfe-generator/images/big-buck-bunny_poster.jpg" width="100%" height="auto">
+  <figure class="videos">
+    <video controls="controls" poster="http://sandbox.thewikies.com/vfe-generator/images/big-buck-bunny_poster.jpg" style="width: 100%;">
       <source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4" />
       <source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.webm" type="video/webm" />
       <source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.ogv" type="video/ogg" />
@@ -10,14 +10,16 @@
         <param name="wmode" value="transparent" />
         <param name="flashVars" value="config={'playlist':['http%3A%2F%2Fsandbox.thewikies.com%2Fvfe-generator%2Fimages%2Fbig-buck-bunny_poster.jpg',{'url':'http%3A%2F%2Fclips.vorwaerts-gmbh.de%2Fbig_buck_bunny.mp4','autoPlay':false}]}" />
         <img alt="Big Buck Bunny" src="http://sandbox.thewikies.com/vfe-generator/images/big-buck-bunny_poster.jpg" width="640" height="360" title="No video playback capabilities, please download the video below" />
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/U9t-slLl30E" frameborder="0" allowfullscreen></iframe>
+        <iframe width="560" height="315" title="Big Buck Bunny on youtube" src="https://www.youtube.com/embed/U9t-slLl30E" frameborder="0" allowfullscreen></iframe>
       </object>
     </video>
-    <div class="videos__transcript">
-      <a href="http://www.example.com/location/of_transcript.htm">Get Transcript</a>
-    </div>
-    <div class="videos__alt-audio">
-      <a href="http://www.example.com/location/of_audiotrack.mp4">Alternative Audio Track</a>
-    </div>
-  </div>
+    <figcaption>
+      <p class="videos__transcript">
+        <a href="http://www.example.com/location/of_transcript.htm">Get Transcript</a>
+      </p>
+      <p class="videos__alt-audio">
+        <a href="http://www.example.com/location/of_audiotrack.mp4">Alternative Audio Track</a>
+      </p>
+    </figcaption>
+  </figure>
 </section>


### PR DESCRIPTION
remove stray </a> from description
update markup example to wrap video within a figure, and the associated transcript & alt. audio in a figcaption
update css to use the video class to remove the figure’s default margin styles