### PR TITLE
site logo css updates

### DIFF
--- a/src/components/site-logo/site-logo.scss
+++ b/src/components/site-logo/site-logo.scss
@@ -23,37 +23,26 @@
 @import '../../global/utils/init';
 
 .site-logo {
-  height: auto;
-  margin: 0;
-  background-size: contain;
-  background-position: center;
-  background-repeat: no-repeat;
-  display: block;
-  max-width: 100%;
-  margin-right: $padding-sm;
-  clear: both;
-  width: 100%;
-  float: left;
 
-  &:focus,
-  &:active,
-  &.active {
-    border-bottom: 0;
+  a {
+    display: inline-block;
+    overflow: hidden;
+
+    &:hover,
+    &:focus {
+      outline: 2px solid #000;
+    }
   }
 
   img {
-    width: 100%;
-    height: auto;
-    float: left;
-    margin-right: 3%;
     max-width: 192px;
+    vertical-align: middle;
   }
 
   h1 {
-    position: absolute;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-    clip: rect(1px, 1px, 1px, 1px);
+    color: #000;
+    display: inline-block;
+    margin: 0 0 0 .25em;
+    vertical-align: middle;
   }
 }


### PR DESCRIPTION
noticed that the logo w/text example had the text hidden.  so removed the styling on the h1 that duplicated the visuallyhidden class.

while cleaning that up, i realized that the site logo class must have originally been on an <a> element, as the styles weren’t really doing anything for the <div>s they were now associated with.  so cleaned up that styling and re-implemented some basic hover/focus states for the <a>s inside the site-logo container.