### PR TITLE
fixing submenu item layout

### DIFF
--- a/src/components/style-guide-theme/style-guide-theme.scss
+++ b/src/components/style-guide-theme/style-guide-theme.scss
@@ -639,8 +639,10 @@ a[target='_blank']::after {
 
   li {
     list-style: none;
-    display: inline-block;
     padding: 0 10px;
+    // @include breakpoint($bp-sm) {
+    //   display: inline-block;
+    // }
   }
 
   a {


### PR DESCRIPTION
something weird was going on with the submenu items in the nav.  the attached screen shot shows how it looks in firefox (left) chrome and safari.

![screen shot 2017-04-19 at 10 21 45 pm](https://cloud.githubusercontent.com/assets/4152514/25210646/ea971778-254e-11e7-9924-1d559185e837.jpg)

removing the display: inline-block on the kss-menu li selector seemed to do the trick though