### PR TITLE
updates

### DIFF
--- a/src/components/navbar-mobile-icon/navbar-mobile-icon.scss
+++ b/src/components/navbar-mobile-icon/navbar-mobile-icon.scss
@@ -2,8 +2,9 @@
 //
 // <ul>
 //  <li>Use the `<button>` element for your mobile navigation icon.</li>
-//  <li>If you use an icon that is purely decoration, no `alt=""` information is needed. If the icon you are using *is* important to the functionality, then supply additional `alt=""` information.</li>
+//  <li>If you use an icon that is purely decoration, declare `alt=""`, as no additional information is needed. If the icon you are using *is* important to the functionality, then supply additional `alt="_descriptive text goes here_"` information.</li>
 //  <li>It is helpful to all users when you add descriptive text when displaying a mobile icon to give more context to the button's purpose.</li>
+//  <li>Place mobile open/close buttons within the `<nav>` element and use them to toggle state of another child wrapper of the nav. This will ensure that the navigation landmark is still discoverable by screen readers, even if it is in a closed / hidden state.</li>
 // </ul>
 //
 // <section data-action="aria-toggle" class="atblock"><h3 class="atblock__title"><a href="#navbaricon_res">Resources</a></h3><div id="navbaricon_res" class="atblock__panel"><ul><li><a href="http://codepen.io/samikeijonen/pen/jqvxdL" target="_blank">Simple and accessible SVG menu hamburger animation</a></li></ul></div></section>

--- a/src/components/navbar-mobile-icon/navbar-mobile-icon.twig
+++ b/src/components/navbar-mobile-icon/navbar-mobile-icon.twig
@@ -1,5 +1,5 @@
 <section class="navbar-mobile-icon">
-  <button class="menu-toggle" id="menu-toggle-ex1" aria-expanded="false"><span class="screen-reader-text">Menu</span>
+  <button class="menu-toggle" id="menu-toggle-ex1" aria-expanded="false" aria-controls="nav-menu-ex-1"><span class="screen-reader-text">Menu</span>
     <svg class="icon icon-menu-toggle" aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100">
       <g class="svg-menu-toggle">
       <path class="line line-1" d="M5 13h90v14H5z"/>
@@ -9,7 +9,7 @@
     </svg>
   </button>
 
-  <button class="menu-toggle" id="menu-toggle-ex2" aria-expanded="false"><span>Click for Menu</span>
+  <button class="menu-toggle" id="menu-toggle-ex2" aria-expanded="false" aria-controls="nav-menu-ex-2"><span>Click for Menu</span>
     <svg class="icon icon-menu-toggle" aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100">
       <g class="svg-menu-toggle">
       <path class="line line-1" d="M5 13h90v14H5z"/>


### PR DESCRIPTION
scss:
add some more info to the navbar mobile icon lead-in bullet points, concerning placement within a navigation for landmark discovery.

also slight wording change for the bullet about alt text, as it read to me that no alt=“” is needed, when i know that’s not what it was trying to say.

twig:
add aria-controls attributes to the buttons.  While only JAWS currently does a good job at supporting aria-controls, is an attribute that __should__ have better support, and it can only help in adding additional context to what the button should be doing.