### PR TITLE
Remove redundant role="navigation" on nav tags

### DIFF
--- a/src/components/navbar/navbar.twig
+++ b/src/components/navbar/navbar.twig
@@ -1,6 +1,6 @@
 <section class="navbar-section">
   <h3>Option #1: List styling with visuallyhidden class</h3>
-  <nav class="navbar" role="navigation">
+  <nav class="navbar">
   	<h2 class="visuallyhidden">Main Menu</h2>
   	<ul class="nav navbar-nav">
       <li class="nav-item">
@@ -19,7 +19,7 @@
   </nav>
   <div class="break"></div>
   <h3>Option #2: List styling with ARIA label</h3>
-  <nav class="navbar" role="navigation" aria-label="Main Menu">
+  <nav class="navbar" aria-label="Main Menu">
     <h2 class="visuallyhidden">Main Menu</h2>
     <ul class="nav navbar-nav">
       <li class="nav-item">


### PR DESCRIPTION
In previous examples user can read 
> Note: this role is implied when you use the <nav> element so it is a bit redundant to use both at the same time.

then seeing the exact opposite can lead to confusion.